### PR TITLE
Add menu bar background mode for Chronicae

### DIFF
--- a/Chronicae/AppSceneRouter.swift
+++ b/Chronicae/AppSceneRouter.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+@MainActor
+final class AppSceneRouter {
+    enum SceneID: String {
+        case main
+    }
+
+    static let shared = AppSceneRouter()
+
+    private var handlers: [UUID: (AppState.Section) -> Void] = [:]
+    private var pendingSection: AppState.Section?
+
+    private init() {}
+
+    func register(_ handler: @escaping (AppState.Section) -> Void) -> UUID {
+        let token = UUID()
+        handlers[token] = handler
+        if let pendingSection {
+            handler(pendingSection)
+            self.pendingSection = nil
+        }
+        return token
+    }
+
+    func unregister(_ token: UUID) {
+        handlers[token] = nil
+    }
+
+    func route(to section: AppState.Section) {
+        if handlers.isEmpty {
+            pendingSection = section
+            return
+        }
+
+        for handler in handlers.values {
+            handler(section)
+        }
+        pendingSection = nil
+    }
+}

--- a/Chronicae/ChronicaeApp.swift
+++ b/Chronicae/ChronicaeApp.swift
@@ -9,9 +9,20 @@ import SwiftUI
 
 @main
 struct ChronicaeApp: App {
+    @NSApplicationDelegateAdaptor(ChronicaeAppDelegate.self) private var appDelegate
+
+    @State private var appState = AppState()
+    @State private var serverManager = ServerManager.shared
+    @StateObject private var loginItemManager = LoginItemManager()
+
     var body: some Scene {
-        WindowGroup {
-            ContentView()
+        WindowGroup(id: AppSceneRouter.SceneID.main.rawValue) {
+            ContentView(appState: appState, serverManager: serverManager)
         }
+
+        MenuBarExtra("Chronicae", systemImage: "server.rack") {
+            MenuBarContentView(serverManager: serverManager, loginItemManager: loginItemManager)
+        }
+        .menuBarExtraStyle(.menu)
     }
 }

--- a/Chronicae/ChronicaeAppDelegate.swift
+++ b/Chronicae/ChronicaeAppDelegate.swift
@@ -1,0 +1,18 @@
+import AppKit
+
+@MainActor
+final class ChronicaeAppDelegate: NSObject, NSApplicationDelegate {
+    private var hasHiddenInitialWindows = false
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(.accessory)
+
+        Task { await ServerManager.shared.startIfNeeded() }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self, !self.hasHiddenInitialWindows else { return }
+            NSApp.windows.filter { $0.isVisible }.forEach { $0.orderOut(nil) }
+            self.hasHiddenInitialWindows = true
+        }
+    }
+}

--- a/Chronicae/MenuBar/LoginItemManager.swift
+++ b/Chronicae/MenuBar/LoginItemManager.swift
@@ -1,0 +1,57 @@
+import Foundation
+import ServiceManagement
+
+@MainActor
+final class LoginItemManager: ObservableObject {
+    @Published private(set) var isEnabled: Bool = false
+    @Published var errorMessage: String?
+    @Published private(set) var isSupported: Bool = true
+
+    private var isUpdating = false
+
+    init() {
+        refresh()
+    }
+
+    func refresh() {
+        guard #available(macOS 13.0, *) else {
+            isSupported = false
+            isEnabled = false
+            return
+        }
+
+        isSupported = true
+        isEnabled = SMAppService.mainApp.status == .enabled
+    }
+
+    func update(enabled: Bool) {
+        guard !isUpdating else { return }
+        guard #available(macOS 13.0, *) else {
+            isSupported = false
+            errorMessage = "이 macOS 버전에서는 로그인 항목을 설정할 수 없습니다."
+            return
+        }
+
+        isUpdating = true
+        Task {
+            do {
+                if enabled {
+                    try SMAppService.mainApp.register()
+                } else {
+                    try SMAppService.mainApp.unregister()
+                }
+                await MainActor.run {
+                    self.isEnabled = enabled
+                    self.errorMessage = nil
+                    self.isUpdating = false
+                }
+            } catch {
+                await MainActor.run {
+                    self.refresh()
+                    self.errorMessage = error.localizedDescription
+                    self.isUpdating = false
+                }
+            }
+        }
+    }
+}

--- a/Chronicae/MenuBar/MenuBarContentView.swift
+++ b/Chronicae/MenuBar/MenuBarContentView.swift
@@ -1,0 +1,123 @@
+import AppKit
+import Observation
+import SwiftUI
+
+struct MenuBarContentView: View {
+    @Bindable var serverManager: ServerManager
+    @ObservedObject var loginItemManager: LoginItemManager
+
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            statusSection
+            Divider()
+            Button("Chronicae 열기") { openMainWindow(for: .dashboard) }
+            Button("저장소 관리") { openMainWindow(for: .storage) }
+            Button("설정") { openMainWindow(for: .settings) }
+            Divider()
+            loginItemToggle
+            if let message = loginItemManager.errorMessage {
+                Text(message)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Divider()
+            Button("Chronicae 종료", role: .destructive) { NSApp.terminate(nil) }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(minWidth: 220)
+    }
+
+    private var statusSection: some View {
+        HStack(spacing: 8) {
+            Image(systemName: statusSymbol)
+                .foregroundStyle(statusColor)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(statusTitle)
+                    .font(.headline)
+                Text(statusSubtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var statusSymbol: String {
+        switch serverManager.status {
+        case .running:
+            return "checkmark.circle.fill"
+        case .starting:
+            return "hourglass"
+        case .error:
+            return "exclamationmark.triangle.fill"
+        case .stopped:
+            return "pause.circle"
+        }
+    }
+
+    private var statusColor: Color {
+        switch serverManager.status {
+        case .running:
+            return .green
+        case .starting:
+            return .yellow
+        case .error:
+            return .red
+        case .stopped:
+            return .secondary
+        }
+    }
+
+    private var statusTitle: String {
+        switch serverManager.status {
+        case .running:
+            return "서버 실행 중"
+        case .starting:
+            return "서버 시작 중"
+        case .error:
+            return "서버 오류"
+        case .stopped:
+            return "서버 중지됨"
+        }
+    }
+
+    private var statusSubtitle: String {
+        switch serverManager.status {
+        case .running(let runtime):
+            return "포트 \(runtime.port)"
+        case .starting:
+            return "초기화 중"
+        case .error(let error):
+            return error.message
+        case .stopped:
+            return "필요 시 수동으로 시작"
+        }
+    }
+
+    private var loginItemToggle: some View {
+        Group {
+            if loginItemManager.isSupported {
+                Toggle("로그인 시 실행", isOn: Binding(
+                    get: { loginItemManager.isEnabled },
+                    set: { loginItemManager.update(enabled: $0) }
+                ))
+                .toggleStyle(.switch)
+            } else {
+                Label("로그인 항목 미지원", systemImage: "bolt.slash")
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+            }
+        }
+    }
+
+    private func openMainWindow(for section: AppState.Section) {
+        openWindow(id: AppSceneRouter.SceneID.main.rawValue)
+        Task { @MainActor in
+            NSApp.activate(ignoringOtherApps: true)
+            AppSceneRouter.shared.route(to: section)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- run the server from a background-only app delegate and hide the initial window
- add a menu bar extra that exposes shortcuts to dashboard, storage, and settings
- support enabling Chronicae as a login item through a dedicated manager

## Testing
- not run (requires macOS tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e081a232888323883825dc98eecadd